### PR TITLE
[ Automated Merge ] : Release Build 1383 is ready for stable merge

### DIFF
--- a/bindings/go/mkv/mkv.go
+++ b/bindings/go/mkv/mkv.go
@@ -27,7 +27,7 @@ import (
     "fmt"
     "flag"
     "log"
-    "../mio"
+    "motr/mio"
 )
 
 func usage() {

--- a/iscservice/ut/service_ut.c
+++ b/iscservice/ut/service_ut.c
@@ -90,7 +90,7 @@ static const struct m0_rpc_item_ops isc_item_ops = {
 enum funct_type {
 	/* Neither receives i/p buffer nor returns anything. */
 	FT_NEITHER_IO,
-	/* Receives no i/p buffer, returns o/p buffer. */
+	/* Receives no i/p buffer, returns error. */
 	FT_NO_INPUT,
 	/* Receives i/p buffer, returns nothing. */
 	FT_NO_OUTPUT,
@@ -244,17 +244,11 @@ static int string_update(struct m0_buf *in, struct m0_buf *out,
 static int strguess(struct m0_buf *in, struct m0_buf *out,
 		    struct m0_isc_comp_private *comp_data, int *rc)
 {
-	char *out_str;
-
-	if (!m0_buf_streq(in, fixed_str)) {
-		out_str = m0_strdup(fixed_str);
-		if (out_str != NULL) {
-			m0_buf_init(out, (void *)out_str, strlen(out_str));
-			*rc = M0_ERR(-EINVAL);
-		} else
-			*rc = M0_ERR(-ENOMEM);
-	} else
+	if (!m0_buf_streq(in, fixed_str))
+		*rc = M0_ERR(-EINVAL);
+	else
 		*rc = 0;
+
 	return M0_FSO_AGAIN;
 }
 
@@ -376,8 +370,7 @@ static void test_comp_launch(void)
 	rc = isc_ut_server_start();
 	M0_UT_ASSERT(rc == 0);
 	reqh = m0_cs_reqh_get(&isc_ut_sctx.rsx_motr_ctx);
-	svc_isc =
-	  m0_reqh_service_find(&m0_iscs_type, reqh);
+	svc_isc = m0_reqh_service_find(&m0_iscs_type, reqh);
 	M0_UT_ASSERT(svc_isc != NULL);
 	fid_get("null_computation", &fid);
 	/* Test a local invocation of computation. */
@@ -767,7 +760,6 @@ static void remote_invocation(struct m0_fid *fid, int exp_rc, uint32_t f_type, u
 		break;
 	case FT_NO_INPUT:
 		M0_UT_ASSERT(ret_rc == 0);
-		M0_UT_ASSERT(m0_buf_streq(&recv_buf, fixed_str));
 		break;
 	case FT_BOTH_IO:
 		for (i = 0; i < recv_buf.b_nob; ++i) {
@@ -836,7 +828,7 @@ static void test_comp_signature(void)
 	cra.cra_comp = strguess;
 	comp_remote_invoke(&cra, FT_NO_OUTPUT);
 
-	/* no-i/p and o/p */
+	/* no-i/p and o/p err */
 	cra.cra_name = m0_strdup("strguess");
 	cra.cra_comp = strguess;
 	comp_remote_invoke(&cra, FT_NO_INPUT);

--- a/layout/layout.c
+++ b/layout/layout.c
@@ -86,6 +86,7 @@
 #include "lib/trace.h"
 
 #include "motr/magic.h"
+#include "motr/client_internal.h"
 #include "layout/layout_internal.h"
 #include "layout/layout.h"
 #include "pool/pool.h" /* M0_TL_DESCR_DECLARE(pools, M0_EXTERN) */
@@ -845,6 +846,16 @@ M0_INTERNAL int64_t m0_layout_find_by_buffsize(struct m0_layout_domain *dom,
 		return M0_ERR_INFO(-EINVAL, "Something went really bad, "
 				   "wrong pver (%p)?", pver);
 	return i;
+}
+
+M0_INTERNAL int64_t m0_layout_find_by_objsz(struct m0_client *cli,
+					    struct m0_fid *pool, size_t sz)
+{
+	struct m0_pool_version *pver;
+
+	return m0_pool_version_get(&cli->m0c_pools_common, pool, &pver) ?:
+	       m0_layout_find_by_buffsize(&cli->m0c_reqh.rh_ldom,
+					  &pver->pv_id, sz);
 }
 
 M0_INTERNAL struct m0_layout *m0_layout_find(struct m0_layout_domain *dom,

--- a/layout/layout.h
+++ b/layout/layout.h
@@ -134,6 +134,7 @@
 
 struct m0_bufvec_cursor;
 struct m0_be_tx;
+struct m0_client;
 
 /* export */
 struct m0_layout_domain;
@@ -746,6 +747,18 @@ M0_INTERNAL struct m0_layout *m0_layout_find(struct m0_layout_domain *dom,
 M0_INTERNAL int64_t m0_layout_find_by_buffsize(struct m0_layout_domain *dom,
 					       struct m0_fid *pver,
 					       size_t buffsize);
+
+/**
+ * Find optimal layout id by pool_id and supposed object size. It's
+ * another variant of m0_layout_find_by_buffsize() which might be easier
+ * to use. The returned layout id can be passed straight away to the
+ * m0_obj_init().
+ *
+ * Returns -EINVAL if cannot find the right layout.
+ */
+M0_INTERNAL int64_t m0_layout_find_by_objsz(struct m0_client *cli,
+					    struct m0_fid *pool, size_t sz);
+
 /**
  * Acquires an additional reference on the layout object.
  * @see m0_layout_put()

--- a/motr/client.c
+++ b/motr/client.c
@@ -412,7 +412,7 @@ void m0_obj_init(struct m0_obj *obj,
 	M0_PRE(parent != NULL);
 	M0_PRE(id != NULL);
 	M0_PRE(entity_id_is_valid(id));
-	M0_PRE(M0_IS0(obj));
+	M0_PRE(M0_IS0(&obj->ob_entity));
 	M0_PRE(layout_id < m0_lid_to_unit_map_nr);
 
 	/* Initalise the entity */
@@ -420,7 +420,7 @@ void m0_obj_init(struct m0_obj *obj,
 
 	/* set the blocksize to a reasonable default */
 	obj->ob_attr.oa_bshift = M0_DEFAULT_BUF_SHIFT;
-	obj_size = obj->ob_attr.oa_obj_size;
+	obj_size = obj->ob_attr.oa_buf_size;
 	obj->ob_attr.oa_layout_id = obj_size == 0 && layout_id == 0 ?
 					M0_DEFAULT_LAYOUT_ID : layout_id;
 

--- a/motr/client.h
+++ b/motr/client.h
@@ -717,11 +717,11 @@ struct m0_obj_attr {
 	/** Pool version fid */
 	struct m0_fid oa_pver;
 
-	/** 
-	 * Size of the object. Set this before m0_obj_init() to generate
+	/**
+	 * Buffer size for object IO. Set this before m0_obj_init() to generate
 	 * optimal layout id during m0_entity_create().
 	 */
-	size_t        oa_obj_size;
+	size_t        oa_buf_size;
 };
 
 /**
@@ -1318,7 +1318,7 @@ void m0__dtx_init     (struct m0__dtx             *dtx,
  * set to default value 'M0_DEFAULT_BUF_SHIFT'.
  *
  * If layout_id == 0, then this object will be set with optimal layout id
- * according to the object size set in m0_obj::ob_attr::oa_obj_size.
+ * according to the object size set in m0_obj::ob_attr::oa_buf_size.
  * If Object size is not set, then this object will be set with
  * default layout id (See struct m0_obj_attr).
  *

--- a/motr/obj.c
+++ b/motr/obj.c
@@ -411,7 +411,7 @@ m0__obj_layout_instance_build(struct m0_client *cinst,
 	 */
 	layout = m0_layout_find(&cinst->m0c_reqh.rh_ldom, layout_id);
 	if (layout == NULL) {
-		rc = -EINVAL;
+		rc = M0_ERR(-EINVAL);
 		goto out;
 	}
 
@@ -524,18 +524,20 @@ static int obj_namei_op_init(struct m0_entity *entity,
 
 	/* Get a layout instance for the object. */
 	lid = m0_pool_version2layout_id(&oo->oo_pver,
-				 	m0__obj_layout_id_get(oo));
+					m0__obj_layout_id_get(oo));
 	rc = m0__obj_layout_instance_build(cinst, lid,
 					   &oo->oo_fid, &linst);
-	if (rc != 0)
+	if (rc != 0) {
+		M0_ERR(rc);
 		goto error;
+	}
 	oo->oo_layout_instance = linst;
 
 #ifdef CLIENT_FOR_M0T1FS
 	/* Set the object's parent's fid. */
 	if (!m0_fid_is_set(&cinst->m0c_root_fid) ||
 	    !m0_fid_is_valid(&cinst->m0c_root_fid)) {
-		rc = -EINVAL;
+		rc = M0_ERR(-EINVAL);
 		goto error;
 	}
 	oo->oo_pfid = cinst->m0c_root_fid;
@@ -543,8 +545,10 @@ static int obj_namei_op_init(struct m0_entity *entity,
 	/* Generate a valid oo_name. */
 	obj_name = m0_alloc(M0_OBJ_NAME_MAX_LEN);
 	rc = obj_fid_make_name(obj_name, M0_OBJ_NAME_MAX_LEN, &oo->oo_fid);
-	if (rc != 0)
+	if (rc != 0) {
+		M0_ERR(rc);
 		goto error;
+	}
 	m0_buf_init(&oo->oo_name, obj_name, strlen(obj_name));
 #endif
 	M0_ASSERT(rc == 0);
@@ -569,7 +573,7 @@ static void obj_optimal_lid_set(struct m0_obj *obj,
 	/* Find optimal layout id when pver id is set and layout id is not */
 	if (*lid == 0 && m0_fid_is_set(&obj->ob_attr.oa_pver)) {
 		*lid = m0_layout_find_by_buffsize(ldom, &obj->ob_attr.oa_pver,
-						  obj->ob_attr.oa_obj_size);
+						  obj->ob_attr.oa_buf_size);
 	}
 	/* Set default layout id when both layout id and pver id is unset */
 	else if (*lid == 0 && !m0_fid_is_set(&obj->ob_attr.oa_pver)) {


### PR DESCRIPTION
RELEASE.INFO => 
 b'---\nNAME: "CORTX"\nVERSION: "2.0.0"\nBRANCH: "main"\nTHIRD_PARTY_VERSION: "centos-7.8.2003-2.0.0-7"\nBUILD: "1383"\nOS: "CentOS Linux release 7.8.2003 (Core)"\nDATETIME: "22-Jun-2021 04:30 UTC"\nKERNEL: "3.10.0_1127.el7"\nCOMPONENTS:\n    - "cortx-cli-2.0.0-849_72e58642.x86_64.rpm"\n    - "cortx-csm_agent-2.0.0-849_72e58642.x86_64.rpm"\n    - "cortx-csm_web-2.0.0-77_1efac5a.x86_64.rpm"\n    - "cortx-ha-2.0.0-110_6b35035.x86_64.rpm"\n    - "cortx-hare-2.0.0-361_git986375b.el7.x86_64.rpm"\n    - "cortx-libsspl_sec-2.0.0-121_gitd4ba2aba.el7.x86_64.rpm"\n    - "cortx-libsspl_sec-method_none-2.0.0-121_gitd4ba2aba.el7.x86_64.rpm"\n    - "cortx-motr-2.0.0-211_gite28e4d36_3.10.0_1127.el7.x86_64.rpm"\n    - "cortx-motr-ivt-2.0.0-211_gite28e4d36_3.10.0_1127.el7.x86_64.rpm"\n    - "cortx-prereq-2.0.0-172_gitaa1bcfe_el7.x86_64.rpm"\n    - "cortx-prvsnr-2.0.0-159_git1e4281cb_el7.x86_64.rpm"\n    - "cortx-py-utils-2.0.0-250_87b21d5.noarch.rpm"\n    - "cortx-s3server-2.0.0-673_gitd281cf17_el7.x86_64.rpm"\n    - "cortx-sspl-2.0.0-121_gitd4ba2aba.el7.noarch.rpm"\n    - "python36-cortx-prvsnr-2.0.52-159_git1e4281cb.x86_64.rpm"\n    - "stats_utils-2.0.0-250_87b21d5.x86_64.rpm"\n    - "uds-pyi-1.3.0-1.r10.el7.x86_64.rpm"\n    - "udx-discovery-0.1.2-3.el7.x86_64.rpm"\n'